### PR TITLE
Handle match without package name

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,4 @@
 linters:
   enable:
     - prealloc
+    - nakedret

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.44.2
+    rev: v1.50.1
     hooks:
       - id: golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,12 @@
 SHELL=bash
 
+setup:
+	pre-commit install
+
 test:
 	cd examples && diff <(sed 's|CURDIR|$(CURDIR)|' expected_results.txt) <(go run .. 2>&1 | sed '/^go: downloading/d')
+
+lint:
+	pre-commit run --all-files
+
+.PHONY: lint test

--- a/README.md
+++ b/README.md
@@ -103,16 +103,16 @@ encoding must start with a `{` or contain line breaks. When using just JSON
 encoding, backslashes must get quoted inside strings. When using YAML, this
 isn't necessary. The following pattern strings are equivalent:
 
-    {msg: "do not write to stdout", Pattern: "^fmt\\.Println$"}
+    {p: "^fmt\\.Println$", msg: "do not write to stdout"}
 
-    {msg: do not write to stdout,
-    Pattern: ^fmt\.Println$
+    {p: ^fmt\.Println$,
+     msg: do not write to stdout,
     }
 
-    {msg: do not write to stdout, pattern: ^fmt\.Println$}
+    {p: ^fmt\.Println$, msg: do not write to stdout}
 
+    p: ^fmt\.Println$
     msg: do not write to stdout
-    pattern: ^fmt\.Println$
 
 A larger set of interesting patterns might include:
 
@@ -122,7 +122,7 @@ A larger set of interesting patterns might include:
 -* `^spew\.Dump$` -- forbid dumping detailed data to stdout
 -* `^spew.ConfigState\.Dump$` -- also forbid it via a `ConfigState`
 -* `^fmt\.Errorf(# please use github\.com/pkg/errors)?$` -- forbid Errorf, with a custom message
--* `{pattern: ^fmt\.Errorf$, msg: please use github.com/pkg/errors}` -- the same with separate msg field
+-* `{p: ^fmt\.Errorf$, msg: please use github.com/pkg/errors}` -- the same with separate msg field
 
 ### Flags
 - **-set_exit_status** (default false) - Set exit status to 1 if any issues are found.

--- a/forbidigo/forbidigo_test.go
+++ b/forbidigo/forbidigo_test.go
@@ -215,7 +215,9 @@ func parseFile(t *testing.T, linter *Linter, expand bool, fileName, contents str
 	}
 	pwd, err := os.Getwd()
 	require.NoError(t, err)
-	defer os.Chdir(pwd)
+	defer func() {
+		_ = os.Chdir(pwd)
+	}()
 	err = os.Chdir(tmpDir)
 	require.NoError(t, err)
 	pkgs, err := packages.Load(&cfg, ".")

--- a/forbidigo/patterns.go
+++ b/forbidigo/patterns.go
@@ -1,11 +1,11 @@
 package forbidigo
 
 import (
+	"encoding"
 	"fmt"
 	"regexp"
 	"regexp/syntax"
 	"strings"
-	"encoding"
 
 	"gopkg.in/yaml.v2"
 )
@@ -17,12 +17,12 @@ type Pattern struct {
 	// Pattern is the regular expression string that is used for matching.
 	// It gets matched against the literal source code text or the expanded
 	// text, depending on the mode in which the analyzer runs.
-	Pattern string `yaml:"pattern" mapstructure:"pattern"`
+	Pattern string `yaml:"p" mapstructure:"p"`
 
 	// Package is a regular expression for the full package path of
 	// an imported item. Ignored unless the analyzer is configured to
 	// determine that information.
-	Package string `yaml:"package,omitempty" mapstructure:"package,omitempty"`
+	Package string `yaml:"pkg,omitempty" mapstructure:"pkg,omitempty"`
 
 	// Msg gets printed in addition to the normal message if a match is
 	// found.

--- a/forbidigo/patterns_test.go
+++ b/forbidigo/patterns_test.go
@@ -46,25 +46,25 @@ func TestParseValidPatterns(t *testing.T) {
 		},
 		{
 			name:            "match import",
-			ptrn:            `{pattern: "^fmt\\.Println$"}`,
+			ptrn:            `{p: "^fmt\\.Println$"}`,
 			expectedPattern: `^fmt\.Println$`,
 		},
 		{
 			name: "match import with YAML",
 			ptrn: `{msg: hello world,
-pattern: ^fmt\.Println$
+p: ^fmt\.Println$
 }`,
 			expectedComment: "hello world",
 			expectedPattern: `^fmt\.Println$`,
 		},
 		{
 			name:            "match import with YAML, no line breaks",
-			ptrn:            `{pattern: ^fmt\.Println$}`,
+			ptrn:            `{p: ^fmt\.Println$}`,
 			expectedPattern: `^fmt\.Println$`,
 		},
 		{
 			name: "simple YAML",
-			ptrn: `pattern: ^fmt\.Println$
+			ptrn: `p: ^fmt\.Println$
 `,
 			expectedPattern: `^fmt\.Println$`,
 		},
@@ -109,12 +109,12 @@ func TestUnmarshalYAML(t *testing.T) {
 		},
 		{
 			name:            "struct: simple expression, no comment",
-			yaml:            `pattern: fmt\.Errorf`,
+			yaml:            `p: fmt\.Errorf`,
 			expectedPattern: `fmt\.Errorf`,
 		},
 		{
 			name: "match import with YAML",
-			yaml: `pattern: ^fmt\.Println$
+			yaml: `p: ^fmt\.Println$
 `,
 			expectedPattern: `^fmt\.Println$`,
 		},
@@ -125,7 +125,7 @@ func TestUnmarshalYAML(t *testing.T) {
 		},
 		{
 			name: "struct: invalid regexp",
-			yaml: `pattern: fmt\
+			yaml: `p: fmt\
 `,
 			expectedErr: "unable to compile source code pattern `fmt\\`: error parsing regexp: trailing backslash at end of expression: ``",
 		},

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.12
 require (
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.4.0
-	golang.org/x/mod v0.7.0 // indirect
 	golang.org/x/tools v0.3.0
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -26,14 +26,15 @@ func TestLiteralAnalyzer(t *testing.T) {
 func TestExpandAnalyzer(t *testing.T) {
 	testdata := analysistest.TestData()
 	patterns := append(forbidigo.DefaultPatterns(),
-		`{pattern: ^pkg\.Forbidden$, package: ^example.com/some/pkg$}`,
-		`{pattern: ^pkg\.CustomType.*Forbidden.*$, package: ^example.com/some/pkg$}`,
-		`{pattern: ^pkg\.CustomInterface.*Forbidden$, package: ^example.com/some/pkg$}`,
-		`{pattern: ^thing\.Shiny, package: ^example.com/some/thing$}`,
-		`{pattern: myCustomStruct\..*Forbidden, package: ^expandtext$}`,
-		`{pattern: myCustomInterface\.AlsoForbidden, package: ^expandtext$}`,
-		`{pattern: renamed\.Forbidden, package: ^example.com/some/renamedpkg$}`,
-		`{pattern: renamed\.Struct.Forbidden, package: ^example.com/some/renamedpkg$}`,
+		`{p: ^pkg\.Forbidden$, pkg: ^example.com/some/pkg$}`,
+		`{p: ^pkg\.CustomType.*Forbidden.*$, pkg: ^example.com/some/pkg$}`,
+		`{p: ^pkg\.CustomInterface.*Forbidden$, pkg: ^example.com/some/pkg$}`,
+		`{p: ^Shiny, pkg: ^example.com/some/thing$}`,
+		`{p: ^thing.AlsoShiny}`,
+		`{p: myCustomStruct\..*Forbidden, pkg: ^expandtext$}`,
+		`{p: myCustomInterface\.AlsoForbidden, pkg: ^expandtext$}`,
+		`{p: renamed\.Forbidden, pkg: ^example.com/some/renamedpkg$}`,
+		`{p: renamed\.Struct.Forbidden, pkg: ^example.com/some/renamedpkg$}`,
 	)
 	a := newAnalyzer(t.Logf)
 	for _, pattern := range patterns {

--- a/pkg/analyzer/testdata/src/example.com/some/thing/thing.go
+++ b/pkg/analyzer/testdata/src/example.com/some/thing/thing.go
@@ -1,3 +1,4 @@
 package thing
 
 var Shiny int
+var AlsoShiny int

--- a/pkg/analyzer/testdata/src/expandtext/expandtext.go
+++ b/pkg/analyzer/testdata/src/expandtext/expandtext.go
@@ -26,7 +26,8 @@ type myCustomInterface interface {
 
 var forbiddenFunctionRef = somepkg.Forbidden // want "somepkg.Forbidden.*forbidden by pattern .*\\^pkg.*Forbidden"
 
-var forbiddenVariableRef = Shiny // want "Shiny.*forbidden by pattern.*\\^thing.*Shiny"
+var forbiddenVariableRef = Shiny      // want "Shiny.*forbidden by pattern.*\\^Shiny"
+var forbiddenVariableRef2 = AlsoShiny // want "Shiny.*forbidden by pattern.*\\^thing.AlsoShiny"
 
 func Foo() {
 	fmt.Println("here I am") // want "forbidden by pattern"


### PR DESCRIPTION
I have a few suggestions in this MR:

1) First, is that I think we can handle matching things like "FDescribe" by returning 2 pieces of text to match when we are looking at just an identifier.
2) Avoid use of "naked return" statements.  I try to avoid these and should probably just run the "nakedret" linter on this repo to prevent them.
3) Go with  shorter names for "pattern" (now just "p") and package (now just "pkg") to match "msg" and generally to keep the patterns terse.